### PR TITLE
Add EEPROM-based logging system with circular queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# PlatformIO
+.pio/
+.ccls-cache/
+.clangd/
+
+# VS Code
+.vscode/
+
+# Build artifacts
+*.elf
+*.bin
+*.hex
+*.map
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Secrets
+arduino_secrets_template.h
+arduino_secrets.h
+secrets*.h
+*.env

--- a/SensorUnit/src/arduino_secrets_template.h
+++ b/SensorUnit/src/arduino_secrets_template.h
@@ -1,12 +1,12 @@
-#ifndef ARDUINO_SECRETS_TEMPLATE_H
-#define ARDUINO_SECRETS_TEMPLATE_H
+#ifndef ARDUINO_SECRET_H
+#define ARDUINO_SECRET_H
 
 // WiFi settings
-constexpr char WIFI_SSID[] = "Tele2_90ED16";
-constexpr char WIFI_PASSWORD[] = "wqx42qeb";
+constexpr char WIFI_SSID[] = "YOUR_WIFI_SSID";
+constexpr char WIFI_PASSWORD[] = "YOUR_WIFI_PASSWORD";
 
 // MQTT Broker settings
-constexpr char MQTT_BROKER[] = "192.168.0.31";
+constexpr char MQTT_BROKER[] = "MQTT_BROKER_IP";
 constexpr unsigned int MQTT_PORT = 1883;
 
 #endif // ARDUINO_SECRET_H

--- a/SensorUnit/src/arduino_secrets_template.h
+++ b/SensorUnit/src/arduino_secrets_template.h
@@ -1,12 +1,12 @@
-#ifndef ARDUINO_SECRET_H
-#define ARDUINO_SECRET_H
+#ifndef ARDUINO_SECRETS_TEMPLATE_H
+#define ARDUINO_SECRETS_TEMPLATE_H
 
 // WiFi settings
-constexpr char WIFI_SSID[] = "YOUR_WIFI_SSID";
-constexpr char WIFI_PASSWORD[] = "YOUR_WIFI_PASSWORD";
+constexpr char WIFI_SSID[] = "Tele2_90ED16";
+constexpr char WIFI_PASSWORD[] = "wqx42qeb";
 
 // MQTT Broker settings
-constexpr char MQTT_BROKER[] = "MQTT_BROKER_IP";
+constexpr char MQTT_BROKER[] = "192.168.0.31";
 constexpr unsigned int MQTT_PORT = 1883;
 
 #endif // ARDUINO_SECRET_H

--- a/SensorUnit/src/eeprom_logging.cpp
+++ b/SensorUnit/src/eeprom_logging.cpp
@@ -1,0 +1,103 @@
+#include "eeprom_logging.h"
+
+namespace Elog
+{
+    //Variables for handling log-queue
+    static uint16_t readIndex  = 0;
+    static uint16_t writeIndex = 0;
+    static uint16_t queueCount = 0;
+
+    // Local helper: calculate the starting address for a slot
+    static inline size_t slotAddress(uint16_t index)
+    {
+        return DATA_BASE + (static_cast<size_t>(index) % CAPACITY) * RECORD_SIZE;
+    }
+
+    static uint32_t readSequence()
+    {
+        uint32_t value = 0;
+        value |=(uint32_t)EEPROM.read(SEQ_ADDRESS + 0);
+        value |=(uint32_t)EEPROM.read(SEQ_ADDRESS + 1 ) << 8;
+        value |=(uint32_t)EEPROM.read(SEQ_ADDRESS + 2 ) << 16;
+        value |=(uint32_t)EEPROM.read(SEQ_ADDRESS + 3 ) << 24;
+        return value;
+    }
+
+    static void writeSequence(uint32_t value)
+    {
+        EEPROM.update(SEQ_ADDRESS + 0, (uint8_t)(value & 0xFF));
+        EEPROM.update(SEQ_ADDRESS + 1, (uint8_t)((value >> 8) & 0xFF));
+        EEPROM.update(SEQ_ADDRESS + 2, (uint8_t)((value >> 16) & 0xFF));
+        EEPROM.update(SEQ_ADDRESS + 3, (uint8_t)((value >> 24) & 0xFF));
+    }
+
+    uint32_t getAndIncrementSequence()
+    {
+        uint32_t current = readSequence();
+        writeSequence(current + 1);
+        return current;
+    }
+
+    void enqueuePayload(const char payload[RECORD_SIZE])
+    {
+        // Write payload at current "WriteIndex"-slot
+        writeToEeprom(payload, writeIndex);
+
+        // calculate new index/count
+        uint16_t newWrite = (uint16_t)(writeIndex + 1);
+        if(newWrite >= CAPACITY) newWrite = 0;
+
+        uint16_t newRead = readIndex;
+        uint16_t newCount = queueCount;
+
+        if(newCount < CAPACITY)
+        {
+            newCount = static_cast<uint16_t>(newCount + 1);
+        }
+        else
+        {
+            // Queue full: overwrite oldest and move readIndex forward
+            newRead = static_cast<uint16_t>(newRead + 1);
+            if(newRead >= CAPACITY) newRead = 0;
+        }
+
+        // Save new meta-values to EEPROM (low byte, high byte)
+        EEPROM.update(WRITE_INDEX_ADDRESS + 0, static_cast<uint8_t>(newWrite & 0xFF));
+        EEPROM.update(WRITE_INDEX_ADDRESS + 1, static_cast<uint8_t>((newWrite >> 8) & 0xFF));
+
+        EEPROM.update(COUNT_ADDRESS + 0, static_cast<uint8_t>(newCount & 0xFF));
+        EEPROM.update(COUNT_ADDRESS + 1, static_cast<uint8_t>((newCount >> 8) & 0xFF));
+
+        EEPROM.update(READ_INDEX_ADDRESS + 0, static_cast<uint8_t>(newRead & 0xFF));
+        EEPROM.update(READ_INDEX_ADDRESS + 1, static_cast<uint8_t>((newRead >> 8) & 0xFF));
+
+        // Update RAM-copies
+        writeIndex = newWrite;
+        readIndex  = newRead;
+        queueCount = newCount; 
+    }
+
+    // Finds next free slot and writes the json-payload to the EEPROM
+    void writeToEeprom(const char payload[RECORD_SIZE], uint16_t index)
+    {
+        const size_t base = slotAddress(index);
+        for (size_t i = 0; i < RECORD_SIZE; i++)
+        {
+            EEPROM.update(base + i, payload[i]);
+        }
+    }
+
+    // ONLY TEMPORARY FOR DEBUGGING!!!
+    uint16_t getReadIndex()  { return readIndex;  }
+    uint16_t getWriteIndex() { return writeIndex; }
+    uint16_t getQueueCount() { return queueCount; }
+    void readFromEeprom(uint16_t index, char out[RECORD_SIZE])
+    {
+        const size_t base = slotAddress(index);
+        for(size_t i = 0; i < RECORD_SIZE; i++)
+        {
+            out[i] = EEPROM.read(base + i);
+        }
+        out[RECORD_SIZE - 1] = '\0'; // Make sure last char is '\0'
+    }
+}

--- a/SensorUnit/src/eeprom_logging.h
+++ b/SensorUnit/src/eeprom_logging.h
@@ -1,0 +1,44 @@
+#ifndef EEPROM_LOGGING_H
+#define EEPROM_LOGGING_H
+
+#include <Arduino.h>
+#include <EEPROM.h>
+
+// Minimal layout for JSON-queue
+namespace Elog
+{
+    constexpr size_t BASE        = 0;      // Start of the EEPROM
+    constexpr size_t RECORD_SIZE = 256;    // Bytes per JSON-post
+    constexpr size_t META_SIZE   = 10;     // Reserved space for "Read-index", "Write-index" and "count"
+    constexpr size_t EEPROM_SIZE = 8192;   // Reserved total bytes (Currently all)
+
+    // Meta field addresses
+    constexpr size_t READ_INDEX_ADDRESS  = BASE + 0;
+    constexpr size_t WRITE_INDEX_ADDRESS = BASE + 2;
+    constexpr size_t COUNT_ADDRESS       = BASE + 4;
+    constexpr size_t SEQ_ADDRESS         = BASE + 6;
+
+    // Data region
+    constexpr size_t DATA_BASE = BASE + META_SIZE;
+    constexpr size_t CAPACITY  = (EEPROM_SIZE - META_SIZE) / RECORD_SIZE;
+    constexpr size_t MAXJSON_CHARS = RECORD_SIZE - 1;
+
+    //Functions for handling the post-queue
+    uint32_t getAndIncrementSequence();
+    void enqueuePayload(const char payload[RECORD_SIZE]);
+
+    // Fucntion that writes a json-payload to the EEPROM
+    void writeToEeprom(const char payload[RECORD_SIZE], uint16_t index);
+    void readFromEeprom(uint16_t index, char out[RECORD_SIZE]);
+
+    //Debug getters
+    uint16_t getReadIndex();
+    uint16_t getWriteIndex();
+    uint16_t getQueueCount();
+
+    // Compile-time sanity checks
+    static_assert(META_SIZE == 10, "META_SIZE must be exactly 10 bytes");
+    static_assert(CAPACITY > 0, "EEPROM_SIZE too small for at least 1 record");
+}
+
+#endif


### PR DESCRIPTION
This merge introduces an EEPROM-backed logging mechanism for persisting sensor payloads across device resets and power loss.

## Changes
- Implemented a fixed-size circular buffer in EEPROM (`RECORD_SIZE = 256` bytes per slot).
- Added metadata storage (`readIndex`, `writeIndex`, `queueCount`, `sequence`) for robust queue management.
- Supports enqueueing payloads, overwriting the oldest entry when full.
- Provides helper functions for reading payloads back from EEPROM.
- Sequence counter ensures unique IDs across reboots.
- Uses `EEPROM.update()` to minimize wear on flash cells.

## Purpose
This lays the groundwork for reliable offline storage of sensor data, ensuring that messages are not lost if network connectivity is unavailable.